### PR TITLE
Make TimeoutDriver public

### DIFF
--- a/driver.go
+++ b/driver.go
@@ -13,14 +13,16 @@ import (
 )
 
 func init() {
-	sql.Register("pq-timeouts", timeoutDriver{dialOpen: pq.DialOpen})
+	sql.Register("pq-timeouts", &TimeoutDriver{dialOpen: pq.DialOpen})
 }
 
-type timeoutDriver struct {
+// TimeoutDriver is the Postgres database driver, providing read and write timeouts.
+type TimeoutDriver struct {
 	dialOpen func(pq.Dialer, string) (driver.Conn, error) // Allow this to be stubbed for testing
 }
 
-func (t timeoutDriver) Open(connection string) (_ driver.Conn, err error) {
+// Open creates a new connection to the database by using the given connection string.
+func (t TimeoutDriver) Open(connection string) (_ driver.Conn, err error) {
 	// Look for read_timeout and write_timeout in the connection string and extract the values.
 	// read_timeout and write_timeout need to be removed from the connection string before calling pq as well.
 	var newConnectionSettings []string

--- a/driver.go
+++ b/driver.go
@@ -13,12 +13,12 @@ import (
 )
 
 func init() {
-	sql.Register("pq-timeouts", &TimeoutDriver{dialOpen: pq.DialOpen})
+	sql.Register("pq-timeouts", &TimeoutDriver{DialOpen: pq.DialOpen})
 }
 
 // TimeoutDriver is the Postgres database driver, providing read and write timeouts.
 type TimeoutDriver struct {
-	dialOpen func(pq.Dialer, string) (driver.Conn, error) // Allow this to be stubbed for testing
+	DialOpen func(pq.Dialer, string) (driver.Conn, error) // Allow this to be stubbed for testing
 }
 
 // Open creates a new connection to the database by using the given connection string.
@@ -58,7 +58,7 @@ func (t TimeoutDriver) Open(connection string) (_ driver.Conn, err error) {
 
 	newConnectionStr := strings.Join(newConnectionSettings, " ")
 
-	return t.dialOpen(
+	return t.DialOpen(
 		timeoutDialer{
 			netDial:        net.Dial,
 			netDialTimeout: net.DialTimeout,

--- a/driver_test.go
+++ b/driver_test.go
@@ -19,7 +19,7 @@ func TestOpenNoTimeoutsAdded(t *testing.T) {
 		return nil, nil
 	}
 
-	driver := timeoutDriver{dialOpen: testDialOpen}
+	driver := TimeoutDriver{dialOpen: testDialOpen}
 
 	testConnection := "user=pqtest dbname=pqtest sslmode=verify-full"
 	_, err := driver.Open(testConnection)
@@ -47,7 +47,7 @@ func TestOpenReadTimeoutAdded(t *testing.T) {
 		return nil, nil
 	}
 
-	driver := timeoutDriver{dialOpen: testDialOpen}
+	driver := TimeoutDriver{dialOpen: testDialOpen}
 
 	_, err := driver.Open("user=pqtest read_timeout=700 dbname=pqtest sslmode=verify-full")
 
@@ -82,7 +82,7 @@ func TestOpenWriteTimeoutAdded(t *testing.T) {
 		return nil, nil
 	}
 
-	driver := timeoutDriver{dialOpen: testDialOpen}
+	driver := TimeoutDriver{dialOpen: testDialOpen}
 
 	_, err := driver.Open(" user=pqtest write_timeout=968      dbname=pqtest sslmode=verify-full		")
 
@@ -115,7 +115,7 @@ func TestOpenTimeoutsAddedWriteError(t *testing.T) {
 		return nil, nil
 	}
 
-	driver := timeoutDriver{dialOpen: testDialOpen}
+	driver := TimeoutDriver{dialOpen: testDialOpen}
 
 	_, err := driver.Open(" user=pqtest write_timeout=seven read_timeout=7    dbname=pqtest sslmode=verify-full		")
 
@@ -140,7 +140,7 @@ func TestOpenTimeoutsAddedReadError(t *testing.T) {
 		return nil, nil
 	}
 
-	driver := timeoutDriver{dialOpen: testDialOpen}
+	driver := TimeoutDriver{dialOpen: testDialOpen}
 
 	_, err := driver.Open(" user=pqtest    write_timeout=680 read_timeout=    dbname=pqtest sslmode=verify-full		")
 
@@ -167,7 +167,7 @@ func TestPostgresURL(t *testing.T) {
 		return nil, nil
 	}
 
-	driver := timeoutDriver{dialOpen: testDialOpen}
+	driver := TimeoutDriver{dialOpen: testDialOpen}
 
 	_, err := driver.Open("postgres://pqtest:password@localhost/pqtest?read_timeout=500&sslmode=verify-full&write_timeout=100")
 
@@ -201,7 +201,7 @@ func TestPostgresqlURLError(t *testing.T) {
 		return nil, nil
 	}
 
-	driver := timeoutDriver{dialOpen: testDialOpen}
+	driver := TimeoutDriver{dialOpen: testDialOpen}
 
 	_, err := driver.Open("postgresql://pqtest\\\\/:password@localhost/pqtest?read_timeout=500&sslmode=verify-full&write_timeout=100")
 

--- a/driver_test.go
+++ b/driver_test.go
@@ -19,7 +19,7 @@ func TestOpenNoTimeoutsAdded(t *testing.T) {
 		return nil, nil
 	}
 
-	driver := TimeoutDriver{dialOpen: testDialOpen}
+	driver := TimeoutDriver{DialOpen: testDialOpen}
 
 	testConnection := "user=pqtest dbname=pqtest sslmode=verify-full"
 	_, err := driver.Open(testConnection)
@@ -47,7 +47,7 @@ func TestOpenReadTimeoutAdded(t *testing.T) {
 		return nil, nil
 	}
 
-	driver := TimeoutDriver{dialOpen: testDialOpen}
+	driver := TimeoutDriver{DialOpen: testDialOpen}
 
 	_, err := driver.Open("user=pqtest read_timeout=700 dbname=pqtest sslmode=verify-full")
 
@@ -82,7 +82,7 @@ func TestOpenWriteTimeoutAdded(t *testing.T) {
 		return nil, nil
 	}
 
-	driver := TimeoutDriver{dialOpen: testDialOpen}
+	driver := TimeoutDriver{DialOpen: testDialOpen}
 
 	_, err := driver.Open(" user=pqtest write_timeout=968      dbname=pqtest sslmode=verify-full		")
 
@@ -115,7 +115,7 @@ func TestOpenTimeoutsAddedWriteError(t *testing.T) {
 		return nil, nil
 	}
 
-	driver := TimeoutDriver{dialOpen: testDialOpen}
+	driver := TimeoutDriver{DialOpen: testDialOpen}
 
 	_, err := driver.Open(" user=pqtest write_timeout=seven read_timeout=7    dbname=pqtest sslmode=verify-full		")
 
@@ -140,7 +140,7 @@ func TestOpenTimeoutsAddedReadError(t *testing.T) {
 		return nil, nil
 	}
 
-	driver := TimeoutDriver{dialOpen: testDialOpen}
+	driver := TimeoutDriver{DialOpen: testDialOpen}
 
 	_, err := driver.Open(" user=pqtest    write_timeout=680 read_timeout=    dbname=pqtest sslmode=verify-full		")
 
@@ -167,7 +167,7 @@ func TestPostgresURL(t *testing.T) {
 		return nil, nil
 	}
 
-	driver := TimeoutDriver{dialOpen: testDialOpen}
+	driver := TimeoutDriver{DialOpen: testDialOpen}
 
 	_, err := driver.Open("postgres://pqtest:password@localhost/pqtest?read_timeout=500&sslmode=verify-full&write_timeout=100")
 
@@ -201,7 +201,7 @@ func TestPostgresqlURLError(t *testing.T) {
 		return nil, nil
 	}
 
-	driver := TimeoutDriver{dialOpen: testDialOpen}
+	driver := TimeoutDriver{DialOpen: testDialOpen}
 
 	_, err := driver.Open("postgresql://pqtest\\\\/:password@localhost/pqtest?read_timeout=500&sslmode=verify-full&write_timeout=100")
 


### PR DESCRIPTION
Expose TimeoutDriver so that it can be wrapped in other drivers, for instance for tracing purposes.

This PR addresses https://github.com/Kount/pq-timeouts/issues/2