### PR TITLE
update url connection-string handling to work with modern `pq`

### DIFF
--- a/driver.go
+++ b/driver.go
@@ -38,15 +38,17 @@ func (t timeoutDriver) Open(connection string) (_ driver.Conn, err error) {
 	for _, setting := range strings.Fields(connection) {
 		s := strings.Split(setting, "=")
 		if s[0] == "read_timeout" {
-			val, err := strconv.Atoi(s[1])
+			trimmed := strings.Trim(s[1], "'")
+			val, err := strconv.Atoi(trimmed)
 			if err != nil {
-				return nil, fmt.Errorf("Error interpreting value for read_timeout")
+				return nil, fmt.Errorf("Error interpreting value %#v for read_timeout", trimmed)
 			}
 			readTimeout = time.Duration(val) * time.Millisecond // timeout is in milliseconds
 		} else if s[0] == "write_timeout" {
-			val, err := strconv.Atoi(s[1])
+			trimmed := strings.Trim(s[1], "'")
+			val, err := strconv.Atoi(trimmed)
 			if err != nil {
-				return nil, fmt.Errorf("Error interpreting value for write_timeout")
+				return nil, fmt.Errorf("Error interpreting value %#v for write_timeout", trimmed)
 			}
 			writeTimeout = time.Duration(val) * time.Millisecond // timeout is in milliseconds
 		} else {

--- a/driver_test.go
+++ b/driver_test.go
@@ -123,7 +123,7 @@ func TestOpenTimeoutsAddedWriteError(t *testing.T) {
 		t.Error("An error was expected")
 	}
 
-	if err.Error() != "Error interpreting value for write_timeout" {
+	if err.Error() != "Error interpreting value \"seven\" for write_timeout" {
 		t.Errorf("The error is unexpected: %q", err.Error())
 	}
 
@@ -148,7 +148,7 @@ func TestOpenTimeoutsAddedReadError(t *testing.T) {
 		t.Error("An error was expected")
 	}
 
-	if err.Error() != "Error interpreting value for read_timeout" {
+	if err.Error() != "Error interpreting value \"\" for read_timeout" {
 		t.Errorf("The error is unexpected: %q", err.Error())
 	}
 
@@ -175,7 +175,9 @@ func TestPostgresURL(t *testing.T) {
 		t.Error("Unexpected error")
 	}
 
-	if connection != "dbname=pqtest host=localhost password=password sslmode=verify-full user=pqtest" {
+	// may be quoted depending on pq version
+	if connection != "dbname=pqtest host=localhost password=password sslmode=verify-full user=pqtest" &&
+		connection != "dbname='pqtest' host='localhost' password='password' sslmode='verify-full' user='pqtest'" {
 		t.Errorf("The connection string was not as expected: %q", connection)
 	}
 
@@ -209,7 +211,9 @@ func TestPostgresqlURLError(t *testing.T) {
 		t.Error("An error was expected")
 	}
 
-	if err.Error() != "parse postgresql://pqtest\\\\/:password@localhost/pqtest?read_timeout=500&sslmode=verify-full&write_timeout=100: invalid character \"\\\\\" in host name" {
+	// may be quoted depending on pq version
+	if err.Error() != "parse postgresql://pqtest\\\\/:password@localhost/pqtest?read_timeout=500&sslmode=verify-full&write_timeout=100: invalid character \"\\\\\" in host name" &&
+		err.Error() != "parse \"postgresql://pqtest\\\\\\\\/:password@localhost/pqtest?read_timeout=500&sslmode=verify-full&write_timeout=100\": invalid character \"\\\\\" in host name" {
 		t.Errorf("The error was not as expected: %q", err.Error())
 	}
 


### PR DESCRIPTION
Since https://github.com/lib/pq/pull/818, `pq.ParseURL` will now quote the values in returned strings, so trim these if present. Also improve the parsing error message to include the troublesome string in question.

While we're at it, update driver tests to handle responses that newer `pq` versions may produce.